### PR TITLE
fix: an attempt to fix uninformative error logging

### DIFF
--- a/src/create-repo.ts
+++ b/src/create-repo.ts
@@ -47,7 +47,7 @@ const createRepo = async () => {
     console.log(`Link to the repo https://github.com/${owner}/${repo}`);
     notifyDiscord(discordWebhook, `Repo **${repo}** successfully created 🚀 \nLink to the repo https://github.com/${owner}/${repo}`);
   } catch (err) {
-    console.error(err);
+    console.error(JSON.stringify(err, null, 2));
     await notifyDiscord(
       discordWebhook,
       `Repo **${repo}** creation failed ❌ please check the detailed logs at: https://github.com/defi-wonderland/repo-creatooor/actions/workflows/repo-creation.yml`


### PR DESCRIPTION
Whenever something goes wrong during creation of a repo, the following message is printed in the logs:
```json
data: {
  message: 'Validation Failed',
  errors: [Array],
  ...other stuff
}
```

Note that there is no way of telling what exactly has happened. This PR is a quick fix for the problem.